### PR TITLE
allow multiple attributes with the same name for CAS3

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -82,7 +82,16 @@ def _verify_cas3(ticket, service):
                     user = element.text
                elif element.tag.endswith('attributes'):
                     for attribute in element:
-                        attributes[attribute.tag.split("}").pop()] = attribute.text
+                        tag = attribute.tag.split("}").pop()
+                        if tag in attributes:
+                            if isinstance(attributes[tag], list):
+                                attributes[tag].append(attribute.text)
+                            else:
+                                attributes[tag] = [attributes[tag]]
+                                attributes[tag].append(attribute.text)
+                        else:
+                            attributes[tag] = attribute.text
+
         return user, attributes
     finally:
         page.close()


### PR DESCRIPTION
Hi,

we have a use-case, where our CAS server sends a list of attributes from /proxyValidate with the same attribute name (roles list).
This fix return the list of values whenever there is more than one attribute with the same name.

Please let me know if there is anything else which needs to be done to get this merged.

Piotr
