### PR TITLE
get tests passing on django 1.5 and 1.6

### DIFF
--- a/tests/test_views_helpers.py
+++ b/tests/test_views_helpers.py
@@ -23,7 +23,8 @@ def test_service_url_helper():
 
 def test_service_url_helper_as_https():
     factory = RequestFactory()
-    request = factory.get('/login/', secure=True)
+    kwargs = {'secure': True, 'wsgi.url_scheme': 'https', 'SERVER_PORT': '443'}
+    request = factory.get('/login/', **kwargs)
 
     actual = _service_url(request)
     expected = 'https://testserver/login/'
@@ -33,10 +34,10 @@ def test_service_url_helper_as_https():
 
 def test_service_url_helper_with_redirect():
     factory = RequestFactory()
-    request = factory.get('/login/', secure=True)
+    request = factory.get('/login/')
 
-    actual = _service_url(request, redirect_to='https://testserver/landing-page/')
-    expected = 'https://testserver/login/?next=https%3A%2F%2Ftestserver%2Flanding-page%2F'
+    actual = _service_url(request, redirect_to='http://testserver/landing-page/')
+    expected = 'http://testserver/login/?next=http%3A%2F%2Ftestserver%2Flanding-page%2F'
 
     assert actual == expected
 
@@ -46,7 +47,7 @@ def test_service_url_helper_with_redirect():
 #
 def test_redirect_url_with_url_as_get_parameter():
     factory = RequestFactory()
-    request = factory.get('/login/', data={'next': '/landing-page/'}, secure=True)
+    request = factory.get('/login/', data={'next': '/landing-page/'})
 
     actual = _redirect_url(request)
     expected = '/landing-page/'
@@ -59,7 +60,7 @@ def test_redirect_url_falls_back_to_cas_redirect_url_setting(settings):
     settings.CAS_REDIRECT_URL = '/landing-page/'
 
     factory = RequestFactory()
-    request = factory.get('/login/', secure=True)
+    request = factory.get('/login/')
 
     actual = _redirect_url(request)
     expected = '/landing-page/'
@@ -72,7 +73,7 @@ def test_params_redirect_url_preceeds_settings_redirect_url(settings):
     settings.CAS_REDIRECT_URL = '/landing-page/'
 
     factory = RequestFactory()
-    request = factory.get('/login/', data={'next': '/override/'}, secure=True)
+    request = factory.get('/login/', data={'next': '/override/'})
 
     actual = _redirect_url(request)
     expected = '/override/'
@@ -85,7 +86,7 @@ def test_redirect_url_falls_back_to_http_referrer(settings):
     settings.CAS_REDIRECT_URL = '/wrong-landing-page/'
 
     factory = RequestFactory()
-    request = factory.get('/login/', secure=True, HTTP_REFERER='/landing-page/')
+    request = factory.get('/login/', HTTP_REFERER='/landing-page/')
 
     actual = _redirect_url(request)
     expected = '/landing-page/'
@@ -95,10 +96,10 @@ def test_redirect_url_falls_back_to_http_referrer(settings):
 
 def test_redirect_url_strips_domain_prefix(settings):
     settings.CAS_IGNORE_REFERER = True
-    settings.CAS_REDIRECT_URL = 'https://testserver/landing-page/'
+    settings.CAS_REDIRECT_URL = 'http://testserver/landing-page/'
 
     factory = RequestFactory()
-    request = factory.get('/login/', secure=True)
+    request = factory.get('/login/')
 
     actual = _redirect_url(request)
     expected = '/landing-page/'
@@ -150,24 +151,24 @@ def test_login_url_helper_with_renew(settings):
 # _login_url tests
 #
 def test_logout_url_helper(settings):
-    settings.CAS_SERVER_URL = 'https://www.example.com/cas/'
+    settings.CAS_SERVER_URL = 'http://www.example.com/cas/'
 
     factory = RequestFactory()
     request = factory.get('/logout/')
 
     actual = _logout_url(request)
-    expected = 'https://www.example.com/cas/logout'
+    expected = 'http://www.example.com/cas/logout'
 
     assert actual == expected
 
 
 def test_logout_url_helper_with_redirect(settings):
-    settings.CAS_SERVER_URL = 'https://www.example.com/cas/'
+    settings.CAS_SERVER_URL = 'http://www.example.com/cas/'
 
     factory = RequestFactory()
     request = factory.get('/logout/')
 
     actual = _logout_url(request, next_page='/landing-page/')
-    expected = 'https://www.example.com/cas/logout?url=http%3A%2F%2Ftestserver%2Flanding-page%2F'
+    expected = 'http://www.example.com/cas/logout?url=http%3A%2F%2Ftestserver%2Flanding-page%2F'
 
     assert actual == expected


### PR DESCRIPTION
### What is the problem / feature ?

Tests were not passing on django 1.5 or 1.6 due to changes in how `django.tests.RequestFactory` sets whether a request is considered secure.
### How did it get fixed / implemented ?

Adjusted how the tests were being called to work with 1.5 and 1.6
### How can someone test / see it ?

See that travis is green

_Here is a cute animal picture for your troubles..._

![cute-panda-bears-animals-34915025-2560-1600](https://cloud.githubusercontent.com/assets/824194/4937619/fa126ae6-65c4-11e4-9dee-03caa1dd499a.jpg)
