### PR TITLE
Refactor cas3 verification and add tests

### DIFF
--- a/tests/test_cas3_verification.py
+++ b/tests/test_cas3_verification.py
@@ -1,0 +1,38 @@
+from django_cas_ng.backends import (
+    verify_cas3_response,
+)
+
+
+SUCCESS_RESPONSE = """<?xml version=\'1.0\' encoding=\'UTF-8\'?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"><cas:authenticationSuccess><cas:user>user@example.com</cas:user></cas:authenticationSuccess></cas:serviceResponse>
+"""
+
+
+SUCCESS_RESPONSE_WITH_ATTRIBUTES = """<?xml version='1.0' encoding='UTF-8'?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"><cas:authenticationSuccess><cas:user>user@example.com</cas:user><cas:attributes><cas:foo>bar</cas:foo><cas:baz>1234</cas:baz></cas:attributes></cas:authenticationSuccess></cas:serviceResponse>
+"""
+
+FAILURE_RESPONSE = """<?xml version='1.0' encoding='UTF-8'?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"><cas:authenticationFailure code="INVALID_TICKET">service ticket ST-1415306486-qs5TfUWlwge23u013h8fivR21RklkeWI has already been used</cas:authenticationFailure></cas:serviceResponse>
+"""
+
+
+def test_basic_successful_response_verification():
+    user, attributes = verify_cas3_response(SUCCESS_RESPONSE)
+
+    assert user == 'user@example.com'
+    assert not attributes
+
+
+def test_successful_response_verification_with_attributes():
+    user, attributes = verify_cas3_response(SUCCESS_RESPONSE_WITH_ATTRIBUTES)
+
+    assert user == 'user@example.com'
+    assert attributes['foo'] == 'bar'
+    assert attributes['baz'] == '1234'
+
+
+def test_unsuccessful_response():
+    user, attributes = verify_cas3_response(FAILURE_RESPONSE)
+    assert user is None
+    assert not attributes


### PR DESCRIPTION
### What is the problem / feature ?
- The `django_cas_ng.backends._verify_cas3` function had no tests.
- The structure of the function was difficult to test, as it made a http request during it's execution.
### How did it get fixed / implemented ?
- first verified it worked as-is using `django-mama-cas` as the CAS server.
- grabbed example successful responses for cas3 verification from the CAS server.
- split the function into two pieces, one that does the http request, and a second that holds the verification business logic.
- Added tests around the business logic against the captured CAS server responses.
### How can someone test / see it ?

Take a look at the code, or see that your cas3 validation still works.

_Here is a cute animal picture for your troubles..._

![bear-cub-playing-with-teddy-bear-big 1](https://cloud.githubusercontent.com/assets/824194/4943848/428827b0-65f8-11e4-9916-c27006783427.jpg)
