### PR TITLE
Fix broken return statment in backend

### DIFF
--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -210,7 +210,7 @@ def _verify_cas2_saml(ticket, service):
                             attributes[at.attrib['AttributeName']] = values_array
                     else:
                         attributes[at.attrib['AttributeName']] = values[0].text
-                        return user, attributes
+        return user, attributes
     finally:
         page.close()
 
@@ -237,15 +237,15 @@ class CASBackend(object):
         username, attributes = _verify(ticket, service)
         if attributes:
             request.session['attributes'] = attributes
-            if not username:
-                return None
+        if not username:
+            return None
         try:
             user = User.objects.get(username=username)
         except User.DoesNotExist:
             # user will have an "unusable" password
             user = User.objects.create_user(username, '')
             user.save()
-            return user
+        return user
 
     def get_user(self, user_id):
         """Retrieve the user's entry in the User model if it exists"""

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -92,10 +92,10 @@ def login(request, next_page=None, required=False):
 
     if not next_page:
         next_page = _redirect_url(request)
-        if request.user.is_authenticated():
-            message = "You are logged in as %s." % request.user.username
-            messages.success(request, message)
-            return HttpResponseRedirect(next_page)
+    if request.user.is_authenticated():
+        message = "You are logged in as %s." % request.user.username
+        messages.success(request, message)
+        return HttpResponseRedirect(next_page)
     ticket = request.GET.get('ticket')
     service = _service_url(request, next_page)
     if ticket:


### PR DESCRIPTION
### What is the problem / feature ?

I broke the backend in 96c67bf459977b582d0d3dd025014b904d2a63ae.

When a user authenticates for the second time, things will break as the backend will just return None since the return statement got nested within the `else` block.
### How did it get fixed / implemented ?

de-dented the return statement.
### How can someone test / see it ?

See that it works?

_Here is a cute animal picture for your troubles..._

![a baa-long-bear-tongue](https://cloud.githubusercontent.com/assets/824194/5000525/d1fca83a-69a9-11e4-816e-8c0383e71957.jpg)
