### PR TITLE
Fixes #10 - Implement signal for successful cas authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,34 @@ your URL mappings::
 
 Users should now be able to log into your site using CAS.
 
+Signals
+-------
+
+``django_cas_ng.signals.cas_user_authenticated``
+
+Sent on successful authentication, the ``CASBackend`` will fire the ``cas_user_authenticated`` signal.
+
+**Arguments sent with this signal**
+
+**sender**
+  The authentication backend instance that authenticated the user.
+
+**user**
+  The user instance that was just authenticated.
+
+**created**
+  Boolean as to whether the user was just created.
+
+**attributes**
+  Attributes returned during by the CAS during authentication.
+
+**ticket**
+  The ticket used to authenticate the user with the CAS.
+
+**service**
+  The service used to authenticate the user with the CAS.
+
+
 Testing
 -------
 

--- a/django_cas_ng/signals.py
+++ b/django_cas_ng/signals.py
@@ -1,0 +1,5 @@
+from django import dispatch
+
+cas_user_authenticated = dispatch.Signal(
+    providing_args=['user', 'created', 'attributes', 'ticket', 'service'],
+)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,99 @@
+import pytest
+
+from django.test import RequestFactory
+from django_cas_ng.backends import CASBackend
+
+
+@pytest.mark.django_db
+def test_backend_authentication_creating_a_user(monkeypatch, django_user_model):
+    """
+    Test the case where CAS authentication is creating a new user.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert user is not None
+    assert user.username == 'test@example.com'
+    assert django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_backend_for_existing_user(monkeypatch, django_user_model):
+    """
+    Test the case where CAS authenticates an existing user.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    existing_user = django_user_model.objects.create_user('test@example.com', '')
+
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert user is not None
+    assert user.username == 'test@example.com'
+    assert user == existing_user
+
+
+@pytest.mark.django_db
+def test_backend_for_failed_auth(monkeypatch, django_user_model):
+    """
+    Test CAS authentication failure.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return None, {}
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert user is None
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,125 @@
+import pytest
+
+from django.test import RequestFactory
+from django.dispatch import receiver
+
+from django_cas_ng.backends import CASBackend
+from django_cas_ng.signals import cas_user_authenticated
+
+
+@pytest.mark.django_db
+def test_signal_when_user_is_created(monkeypatch, django_user_model):
+    """
+    Test that when CAS authentication creates a user, the signal is called with
+    `created = True`
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}
+
+    callback_values = {}
+
+    @receiver(cas_user_authenticated)
+    def callback(sender, **kwargs):
+        callback_values.update(kwargs)
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    # sanity check
+    assert not django_user_model.objects.filter(
+        username='test@example.com',
+    ).exists()
+
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert 'user' in callback_values
+    assert callback_values.get('user') == user
+    assert callback_values.get('created') == True
+    assert 'attributes' in callback_values
+    assert 'ticket' in callback_values
+    assert 'service' in callback_values
+
+
+@pytest.mark.django_db
+def test_signal_when_user_already_exists(monkeypatch, django_user_model):
+    """
+    Test that when CAS authentication creates a user, the signal is called with
+    `created = False`
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return 'test@example.com', {'ticket': ticket, 'service': service}
+
+    callback_values = {}
+
+    @receiver(cas_user_authenticated)
+    def callback(sender, **kwargs):
+        callback_values.update(kwargs)
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    # sanity check
+    existing_user = django_user_model.objects.create_user(
+        'test@example.com', '',
+    )
+
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert 'user' in callback_values
+    assert callback_values.get('user') == user == existing_user
+    assert callback_values.get('created') == False
+    assert 'attributes' in callback_values
+    assert 'ticket' in callback_values
+    assert 'service' in callback_values
+
+
+@pytest.mark.django_db
+def test_signal_not_fired_if_auth_fails(monkeypatch, django_user_model):
+    """
+    Test that the cas_user_authenticated signal is not fired when CAS
+    authentication fails.
+    """
+    factory = RequestFactory()
+    request = factory.get('/login/')
+    request.session = {}
+
+    def mock_verify(ticket, service):
+        return None, {}
+
+    callback_values = {}
+
+    @receiver(cas_user_authenticated)
+    def callback(sender, **kwargs):
+        callback_values.update(kwargs)
+
+    # we mock out the verify method so that we can bypass the external http
+    # calls needed for real authentication since we are testing the logic
+    # around authentication.
+    monkeypatch.setattr('django_cas_ng.backends._verify', mock_verify)
+
+    # sanity check
+    backend = CASBackend()
+    user = backend.authenticate(
+        ticket='fake-ticket', service='fake-service', request=request,
+    )
+
+    assert user is None
+    assert callback_values == {}


### PR DESCRIPTION
### What is the problem / feature ?

The attributes returned by successful authentication with the CAS server are stashed on the request session, meaning that any code that wants to interact with those attributes has to be linked into the request/response cycle.
### How did it get fixed / implemented ?

Implemented a new signal `django_cas_ng.signals.cas_user_authenticated` which is fired on successful authentication by the CAS backend.  This allows for code that cares about attributes or any other part of the CAS authentication to be separate from view code.
### How can someone test / see it ?

Code mostly.  Also look at the README for info on how to use it.

_Here is a cute baby animal picture for your troubles..._

![6933762244_e0aec12df9](https://cloud.githubusercontent.com/assets/824194/5018592/4e935800-6a75-11e4-8665-cb028263585a.jpg)
