### PR TITLE
Removed the ticket GET param from the service, as it could break CAS.

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import re
+
 from django.utils.six.moves import urllib_parse
 
 from django.http import HttpResponseRedirect, HttpResponseForbidden
@@ -29,8 +31,14 @@ def _service_url(request, redirect_to=None):
 
     protocol = get_protocol(request)
     host = request.get_host()
+
+    ticketless_full_path = request.get_full_path()
+    match = re.search(r'(&ticket=[\w\-\.]+)(?:[&].+|$)(?:$|)', ticketless_full_path)
+    if match:
+        ticketless_full_path = ticketless_full_path.replace(match.group(1), "")
+
     service = urllib_parse.urlunparse(
-        (protocol, host, request.get_full_path(), '', '', ''),
+        (protocol, host, ticketless_full_path, '', '', ''),
     )
     if redirect_to:
         if '?' in service:


### PR DESCRIPTION
When interacting with a CAS 2 server (tested against a fairly stock http://jasig.github.io/cas/4.0.0/index.html), this client appends the ticket to the service URL, which modifies the service URL, causing an invalid request to propagate and ultimately fail.

Regex has been added to remove the ticket get parameter from the string generated by request.get_full_path.
