### PR TITLE
Specify version string to prevent dependency hell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     #bugtrack_url='https://github.com/mingchen/django-cas-ng/issues',  # not support this key
     download_url ='https://github.com/mingchen/django-cas-ng/releases',
     version='3.4.0',
-    install_requires=['Django'],
+    install_requires=['Django >= 1.5'],
 )
 


### PR DESCRIPTION
At the moment if I do:

```
pip install --upgrade Django==1.5.8
pip install --upgrade django-cas-ng
```

My resulting django version is 1.7.1 which is incorrect.
