### PR TITLE
Add CAS_CREATE_USER setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ Optional settings include:
 * ``CAS_ADMIN_PREFIX``: The URL prefix of the Django administration site.
   If undefined, the CAS middleware will check the view being rendered to
   see if it lives in ``django.contrib.admin.views``.
+* ``CAS_CREATE_USER``: Create a user when the CAS authentication is successful.
+  The default is ``True``.
 * ``CAS_EXTRA_LOGIN_PARAMS``: Extra URL parameters to add to the login URL
   when redirecting the user. Example::
 

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -245,6 +245,10 @@ class CASBackend(object):
             user = User.objects.get(username=username)
             created = False
         except User.DoesNotExist:
+            # check if we want to create new users, if we don't fail auth
+            create = getattr(settings, 'CAS_CREATE_USER', True)
+            if not create:
+                return None
             # user will have an "unusable" password
             user = User.objects.create_user(username, '')
             user.save()


### PR DESCRIPTION
The setting will give the developer/admin control over whether or not a user is created when the authentication is successful. The default value is true, as this should keep backwards compatibility (and in most cases is what you want). I needed this as I have several internal applications where I want control over specific users that should be allowed to login.
