### PR TITLE
Include setting to always use https in service url

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -30,6 +30,7 @@ _DEFAULTS = {
     'CAS_CREATE_USER_WITH_ID': False,
     'CAS_VERIFY_SSL_CERTIFICATE': True,
     'CAS_LOCAL_NAME_FIELD': None,
+    'CAS_FORCE_SSL_SERVICE_URL': False,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -45,7 +45,10 @@ def get_service_url(request, redirect_to=None):
     if hasattr(django_settings, 'CAS_ROOT_PROXIED_AS'):
         service = django_settings.CAS_ROOT_PROXIED_AS + request.path
     else:
-        protocol = get_protocol(request)
+        if django_settings.CAS_FORCE_SSL_SERVICE_URL:
+            protocol = 'https'
+        else:
+            protocol = get_protocol(request)
         host = request.get_host()
         service = urllib_parse.urlunparse(
             (protocol, host, request.path, '', '', ''),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Listed are the high-level, notable changes for each django-cas-ng release.
 Backwards incompatible changes or other upgrade issues are also described
 here. For additional detail, read the complete `commit history`_.
 
+**django-cas-ng 4.0.2** ``[2020-02-10]``
+
+  * New setting CAS_FORCE_SSL_SERVICE_URL forces the service url to always target HTTPS
+
 **django-cas-ng 4.0.1** ``[2020-01-16]``
 
   * Split README into docs.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -286,6 +286,12 @@ If set, will make user lookup against this field and not model's natural key.
 This allows you to authenticate arbitrary users.
 
 
+``CAS_FORCE_SSL_SERVICE_URL`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Force the service url to always target HTTPS by setting CAS_FORCE_SSL_SERVICE_URL to True.
+
+
 URL dispatcher
 ^^^^^^^^^^^^^^
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,6 +66,18 @@ def test_service_url_root_proxied_as(settings):
     assert actual == expected
 
 
+def test_force_ssl_service_url(settings):
+    settings.CAS_FORCE_SSL_SERVICE_URL = True
+
+    factory = RequestFactory()
+    request = factory.get('/login/')
+
+    actual = get_service_url(request)
+    expected = 'https://testserver/login/?next=%2F'
+
+    assert actual == expected
+
+
 #
 # get_redirect_url tests
 #


### PR DESCRIPTION
When CAS_FORCE_SSL_SERVICE_URL is set to True, the service url will always use https