### PR TITLE
Mark package as PEP 561 typing compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,10 @@ setup(
     name='django-cas-ng',
     packages=['django_cas_ng', 'django_cas_ng.management', 'django_cas_ng.management.commands', 'django_cas_ng.migrations'],
     package_data={
-        'django_cas_ng': ['locale/*/LC_MESSAGES/*'],
+        'django_cas_ng': [
+            'locale/*/LC_MESSAGES/*',
+            'py.typed',
+        ],
     },
     url='https://djangocas.dev',
     download_url='https://github.com/django-cas-ng/django-cas-ng/releases',


### PR DESCRIPTION
This project already contains type annotations. The `py.typed` file is a signal to type checkers such as Mypy so they don't complain about missing type stubs.

Details: https://www.python.org/dev/peps/pep-0561/#packaging-type-information