### PR TITLE
fix: v1 cas client create error

### DIFF
--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -86,7 +86,7 @@ def get_cas_client(service_url=None, request=None):
             "environment."
         )
 
-    return CASClient(
+    kwargs = dict(
         service_url=service_url,
         version=django_settings.CAS_VERSION,
         server_url=server_url,
@@ -96,6 +96,10 @@ def get_cas_client(service_url=None, request=None):
         proxy_callback=django_settings.CAS_PROXY_CALLBACK,
         verify_ssl_certificate=django_settings.CAS_VERIFY_SSL_CERTIFICATE
     )
+    if django_settings.CAS_VERSION == 1:
+        kwargs.pop('proxy_callback')
+
+    return CASClient(**kwargs)
 
 
 def get_user_from_session(session: SessionBase) -> Union[User, AnonymousUser]:


### PR DESCRIPTION
When set CAS_VERSION = 1 on settings will be has Exception, because **CASClientV1** has no args **proxy_callback**, but v2, v3 has

v1 code: https://github.com/python-cas/python-cas/blob/master/cas.py#L158

v2 code: https://github.com/python-cas/python-cas/blob/master/cas.py#L193

Error below:

```
  File "/Users/guang/vm/py/py36/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/guang/projects/django-cas-ng/django_cas_ng/views.py", line 76, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/Users/guang/vm/py/py36/lib/python3.6/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/guang/projects/django-cas-ng/django_cas_ng/views.py", line 111, in get
    client = get_cas_client(service_url=service_url, request=request)
  File "/Users/guang/projects/django-cas-ng/django_cas_ng/utils.py", line 97, in get_cas_client
    verify_ssl_certificate=django_settings.CAS_VERIFY_SSL_CERTIFICATE
  File "/Users/guang/vm/py/py36/lib/python3.6/site-packages/cas.py", line 48, in __new__
    return CASClientV1(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'proxy_callback'
```

so, if version v1 pop this arg
