### PR TITLE
change thrown exception to specific type

### DIFF
--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -15,6 +15,11 @@ from django.contrib.sessions.backends.base import SessionBase
 from django.shortcuts import resolve_url
 
 
+class RedirectException(Exception):
+    """Signals that a redirect could not be handled."""
+    pass
+
+
 def get_protocol(request):
     """Returns 'http' or 'https' for the request protocol"""
     if request.is_secure():

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -30,6 +30,7 @@ from .utils import (
     get_redirect_url,
     get_service_url,
     get_user_from_session,
+    RedirectException
 )
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
@@ -46,7 +47,7 @@ def clean_next_page(request, next_page):
     is_safe = getattr(settings, 'CAS_CHECK_NEXT',
                       lambda _next_page: is_local_url(request.build_absolute_uri('/'), _next_page))
     if not is_safe(next_page):
-        raise Exception("Non-local url is forbidden to be redirected to.")
+        raise RedirectException("Non-local url is forbidden to be redirected to.")
     return next_page
 
 


### PR DESCRIPTION
Sometimes you'll get referrers that are outside your domain (eg. from webmail hosts). To catch these, you'd either have to catch `Exception`, or show an unhandled exception. Both are bad. With this patch, you can simply catch the newly-defined `RedirectException` and handle that accordingly.