### PR TITLE
Add the CAS_ADMIN_REDIRECT option to disable admin redirect

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 __all__ = []
 
 _DEFAULTS = {
+    'CAS_ADMIN_REDIRECT': True,
     'CAS_ADMIN_PREFIX': None,
     'CAS_CREATE_USER': True,
     'CAS_LOGIN_URL_NAME': 'cas_ng_login',

--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -45,10 +45,13 @@ class CASMiddleware(MiddlewareMixin):
         if view_func in (cas_login, cas_logout):
             return None
 
-        if settings.CAS_ADMIN_PREFIX:
-            if not request.path.startswith(settings.CAS_ADMIN_PREFIX):
-                return None
-        elif not view_func.__module__.startswith('django.contrib.admin.'):
+        if settings.CAS_ADMIN_REDIRECT:
+            if settings.CAS_ADMIN_PREFIX:
+                if not request.path.startswith(settings.CAS_ADMIN_PREFIX):
+                    return None
+                elif not view_func.__module__.startswith('django.contrib.admin.'):
+                    return None
+        else:
             return None
 
         if view_func.__name__ == 'logout':


### PR DESCRIPTION
This adds an option to disable the CAS redirect functionality in the
middleware. I use CAS using a mix of CAS accounts and local Django
accounts, so this allows django_cas_ng to support multiple auth methods.
Image attached below, as an example.

![Screenshot_2020-10-23_17-04-38](https://user-images.githubusercontent.com/59292/97054079-1e9c6680-1552-11eb-96c1-12e757067c64.png)
