### PR TITLE
Remove Signal(providing_args=) argument, deprecated in Django 3.1

### DIFF
--- a/django_cas_ng/signals.py
+++ b/django_cas_ng/signals.py
@@ -1,9 +1,8 @@
 from django import dispatch
 
-cas_user_authenticated = dispatch.Signal(
-    providing_args=['user', 'created', 'attributes', 'ticket', 'service', 'request'],
-)
+# Arguments passed to receiver functions are documented at
+# https://djangocas.dev/docs/latest/signals.html
 
-cas_user_logout = dispatch.Signal(
-    providing_args=['user', 'session', 'ticket'],
-)
+cas_user_authenticated = dispatch.Signal()
+
+cas_user_logout = dispatch.Signal()


### PR DESCRIPTION
This argument causes a warning and will be removed in Django 4.0.

It was purely documentational and has no effect on behavior.

Ref: https://code.djangoproject.com/ticket/31327