### PR TITLE
Don't use 'del' statement, to fix deepsource error

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -113,7 +113,7 @@ class LoginView(View):
 
         if not next_page and settings.CAS_STORE_NEXT and 'CASNEXT' in request.session:
             next_page = request.session['CASNEXT']
-            del request.session['CASNEXT']
+            request.session['CASNEXT'] = None
 
         if not next_page:
             next_page = get_redirect_url(request)


### PR DESCRIPTION
This should fix the deepsource error here:
https://deepsource.io/gh/django-cas-ng/django-cas-ng/run/10f19036-c176-4a15-bcf7-843d512f94de/python/PTC-W0043