### PR TITLE
Fix tox isort command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ skip_install = true
 
 [testenv:isort]
 deps = isort
-commands = isort --check-only --diff
+commands = isort --check-only --diff django_cas_ng
 skip_install = true


### PR DESCRIPTION
isort needs the path specified in order to run. This will fix the travis
error created by isort:

https://travis-ci.org/github/django-cas-ng/django-cas-ng/jobs/740363369