### PR TITLE
Bugfix: let checking of the "next" URL parameter be configurable

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -32,6 +32,7 @@ _DEFAULTS = {
     'CAS_VERIFY_SSL_CERTIFICATE': True,
     'CAS_LOCAL_NAME_FIELD': None,
     'CAS_FORCE_SSL_SERVICE_URL': False,
+    'CAS_CHECK_NEXT': True,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -8,6 +8,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
+
 from django_cas_ng.signals import cas_user_authenticated
 
 from .utils import get_cas_client

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union, Optional
+from typing import Optional, Union
 from urllib import parse as urllib_parse
 
 from cas import CASClient

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -39,14 +39,9 @@ __all__ = ['LoginView', 'LogoutView', 'CallbackView']
 
 
 def clean_next_page(request, next_page):
-    """
-    set settings.CAS_CHECK_NEXT to lambda _: True if you want to bypass this check.
-    """
     if not next_page:
         return next_page
-    is_safe = getattr(settings, 'CAS_CHECK_NEXT',
-                      lambda _next_page: is_local_url(request.build_absolute_uri('/'), _next_page))
-    if not is_safe(next_page):
+    if settings.CAS_CHECK_NEXT and not is_local_url(request.build_absolute_uri('/'), next_page):
         raise RedirectException("Non-local url is forbidden to be redirected to.")
     return next_page
 

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -22,15 +22,15 @@ from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
-from .models import ProxyGrantingTicket, SessionTicket, SESSION_KEY_MAXLENGTH
+from .models import SESSION_KEY_MAXLENGTH, ProxyGrantingTicket, SessionTicket
 from .signals import cas_user_logout
 from .utils import (
+    RedirectException,
     get_cas_client,
     get_protocol,
     get_redirect_url,
     get_service_url,
     get_user_from_session,
-    RedirectException
 )
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -304,6 +304,18 @@ Force the service url to always target HTTPS by setting ``CAS_FORCE_SSL_SERVICE_
 
 The default is ``False``.
 
+
+``CAS_CHECK_NEXT`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Available in ``4.1.2``.
+
+The URL provided by `?next` is validated so that only local URLs are allowed. This check can be disabled by
+turning this setting to `False` (e.g. for local development).
+
+The default is ``True``.
+
+
 URL dispatcher
 ^^^^^^^^^^^^^^
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -257,7 +257,7 @@ def test_login_redirect_based_on_cookie(monkeypatch, django_user_model, settings
     assert response.status_code == 302
     assert response['Location'] == '/admin/'
 
-    assert 'CASNEXT' not in request.session
+    assert request.session['CASNEXT'] is None
     assert django_user_model.objects.get(username='test@example.com').is_authenticated is True
 
 


### PR DESCRIPTION
On productive systems, the django settings are casted to an object during application startup, so `settings.CAS_CHECK_NEXT=lambda _: True` is evaluated to `settings.CAS_CHECK_NEXT = True`.

As a callable method is expected by `is_safe` in the views, this raises an Exception (boolean is not a callable).

The change is in commit cd749ace0ca5610819e51f97cb34d0f4da4b4bae, the other two commits simply make the CI happy.