### PR TITLE
Change default of CAS_USERNAME_ATTRIBUTE to fix #284

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -21,7 +21,7 @@ _DEFAULTS = {
     'CAS_RETRY_LOGIN': False,
     'CAS_SERVER_URL': None,
     'CAS_VERSION': '2',
-    'CAS_USERNAME_ATTRIBUTE': 'uid',
+    'CAS_USERNAME_ATTRIBUTE': 'cas:user',
     'CAS_PROXY_CALLBACK': None,
     'CAS_LOGIN_MSG': _("Login succeeded. Welcome, %s."),
     'CAS_LOGGED_MSG': _("You are logged in as %s."),

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -30,7 +30,7 @@ class CASBackend(ModelBackend):
         if attributes and request:
             request.session['attributes'] = attributes
 
-        if settings.CAS_USERNAME_ATTRIBUTE != 'uid' and settings.CAS_VERSION != 'CAS_2_SAML_1_0':
+        if settings.CAS_USERNAME_ATTRIBUTE != 'cas:user' and settings.CAS_VERSION != 'CAS_2_SAML_1_0':
             if attributes:
                 username = attributes.get(settings.CAS_USERNAME_ATTRIBUTE)
             else:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -218,12 +218,12 @@ The default is ``'2'``.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The CAS user name attribute from response.
-If set with a value other than ``uid`` when ``CAS_VERSION`` is not ``'CAS_2_SAML_1_0'``, this
-will be handled by the ``CASBackend``, in which case if the user lacks that attribute then
-authentication will fail. Note that the attribute is checked before ``CAS_RENAME_ATTRIBUTES``
-is applied.
+The default behaviour is to map the cas:user value to the django username.  This attribute allows
+one to override this behaviour and map a different attribute to the username e.g. mail, cn or uid
+This feature is not available when ``CAS_VERSION`` is ``'CAS_2_SAML_1_0'``.
+Note that the attribute is checked before ``CAS_RENAME_ATTRIBUTES`` is applied.
 
-The default is ``uid``.
+The default is ``cas:user``.
 
 
 ``CAS_PROXY_CALLBACK`` [Optional]


### PR DESCRIPTION
This PR updates the default value of

  CAS_USERNAME_ATTRIBUTE = 'cas:user'`

The current value of `uid` prevents users from mapping a real attribute
called uid to the username.  The new value of cas:user is much less
likely to be a real attribute and is much more descriptive about what
meta data is being used

fixes #284 