### PR TITLE
Change in conditional in Middleware to avoid infinite redirects

### DIFF
--- a/django_cas_ng/middleware.py
+++ b/django_cas_ng/middleware.py
@@ -49,8 +49,8 @@ class CASMiddleware(MiddlewareMixin):
             if settings.CAS_ADMIN_PREFIX:
                 if not request.path.startswith(settings.CAS_ADMIN_PREFIX):
                     return None
-                elif not view_func.__module__.startswith('django.contrib.admin.'):
-                    return None
+            elif not view_func.__module__.startswith('django.contrib.admin.'):
+                return None
         else:
             return None
 


### PR DESCRIPTION
Related to #289.
The last conditional statement under `settings.CAS_ADMIN_PREFIX`
would never get executed due to the fact that the first has a
return statement. This commit aims to resolve this.