### PR TITLE
Allow customizing requests Session settings

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -33,6 +33,7 @@ _DEFAULTS = {
     'CAS_LOCAL_NAME_FIELD': None,
     'CAS_FORCE_SSL_SERVICE_URL': False,
     'CAS_CHECK_NEXT': True,
+    'CAS_SESSION_FACTORY': None,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -105,6 +105,8 @@ def get_cas_client(
         proxy_callback=django_settings.CAS_PROXY_CALLBACK,
         verify_ssl_certificate=django_settings.CAS_VERIFY_SSL_CERTIFICATE
     )
+    if django_settings.CAS_SESSION_FACTORY:
+        kwargs['session'] = django_settings.CAS_SESSION_FACTORY()
     if django_settings.CAS_VERSION == 1:
         kwargs.pop('proxy_callback')
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -316,6 +316,31 @@ turning this setting to `False` (e.g. for local development).
 The default is ``True``.
 
 
+``CAS_SESSION_FACTORY`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Available in ``4.2.2``.
+
+Can be a callable that returns a ``requests.Session`` instance. This can be used to to change behaviors when
+doing HTTP requests via the underlying ``requests`` library, such as HTTP headers, proxies, hooks and more.
+See `requests library documentation`_ for more details.
+
+The default is ``None``.
+
+Example usage:
+
+..  code-block:: python
+
+    from requests import Session
+
+    def cas_get_session():
+        session = Session()
+        session.proxies["https"] = "http://proxy.example.org:3128"
+        return session
+
+    CAS_SESSION_FACTORY = cas_get_session
+
+
 URL dispatcher
 ^^^^^^^^^^^^^^
 
@@ -382,3 +407,4 @@ Users should now be able to log into your site using CAS.
 
 .. _simplified URL routing syntax: https://docs.djangoproject.com/en/dev/releases/2.0/#simplified-url-routing-syntax
 .. _clearsessions: https://docs.djangoproject.com/en/1.8/topics/http/sessions/#clearing-the-session-store
+.. _requests library documentation: https://docs.python-requests.org/en/master/user/advanced/#session-objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ lxml>=3.4
 
 # If you want the latest python-cas, uncomment following line.
 #-e git+https://github.com/python-cas/python-cas.git#egg=python_cas
-python-cas==1.5.0
+python-cas==1.6.0
 requests>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         'Django>=2.0',
-        'python-cas>=1.4.0',
+        'python-cas>=1.6.0',
     ],
     zip_safe=False,  # dot not package as egg or django will not found management commands
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,8 @@
+from unittest.mock import Mock
+
+import requests
 from django.test import RequestFactory
-from django_cas_ng.utils import get_redirect_url, get_service_url
+from django_cas_ng.utils import get_redirect_url, get_service_url, get_cas_client
 
 
 #
@@ -193,3 +196,13 @@ def test_redirect_url_next_no_named_pattern(settings):
     expected = 'home'
 
     assert actual == expected
+
+
+def test_session_factory(settings):
+    session = requests.Session()
+    settings.CAS_SESSION_FACTORY = Mock(return_value=session)
+
+    client = get_cas_client()
+
+    assert settings.CAS_SESSION_FACTORY.called
+    assert client.session is session


### PR DESCRIPTION
Added a `CAS_SESSION_FACTORY` setting (must be a callable), which allows customizing many requests behaviors such as HTTP headers, proxies, hooks and more.

My use case requires making all CAS requests through an HTTP proxy.

This depends upon the `python-cas` PR at https://github.com/python-cas/python-cas/pull/44