### PR TITLE
Fix warning on system check from Django 3.2

### DIFF
--- a/django_cas_ng/apps.py
+++ b/django_cas_ng/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CASConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'django_cas_ng'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -89,7 +89,7 @@ The default is ``False``.
 Welcome message send via the messages framework upon
 successful authentication. Take the user login as formatting argument.
 
-You cas disable it by setting this parametter to ``None``
+You can disable it by setting this parameter to ``None``
 
 The default is ``"Login succeeded. Welcome, %s."`` or some translation of it
 if you have enabled django internationalization (``USE_I18N = True``)
@@ -102,7 +102,7 @@ Welcome message send via the messages framework upon
 authentication attempt if the user is already authenticated.
 Take the user login as formatting argument.
 
-You cas disable it by setting this parametter to ``None``
+You can disable it by setting this parameter to ``None``
 
 The default is ``"You are logged in as %s."`` or some translation of it
 if you have enabled django internationalization (``USE_I18N = True``)


### PR DESCRIPTION
Create `apps.py` at application level to avoid this warning:

```
Auto-created primary key used when not defining a primary key type,
    by default 'django.db.models.AutoField'.
```

Refer to the documentation:

https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys

Fixes: #304