### PR TITLE
Fixes the logout service url when using `CAS_ROOT_PROXIED_AS`

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -221,8 +221,11 @@ class LogoutView(View):
 
         next_page = next_page or get_redirect_url(request)
         if settings.CAS_LOGOUT_COMPLETELY:
-            protocol = get_protocol(request)
-            host = request.get_host()
+            if hasattr(settings, 'CAS_ROOT_PROXIED_AS'):
+                protocol, host, _, _, _, _ = urllib_parse.urlparse(settings.CAS_ROOT_PROXIED_AS)
+            else:
+                protocol = get_protocol(request)
+                host = request.get_host()
             redirect_url = urllib_parse.urlunparse(
                 (protocol, host, next_page, '', '', ''),
             )

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -221,7 +221,7 @@ class LogoutView(View):
 
         next_page = next_page or get_redirect_url(request)
         if settings.CAS_LOGOUT_COMPLETELY:
-            if hasattr(settings, 'CAS_ROOT_PROXIED_AS'):
+            if hasattr(settings, 'CAS_ROOT_PROXIED_AS') and settings.CAS_ROOT_PROXIED_AS:
                 protocol, host, _, _, _, _ = urllib_parse.urlparse(settings.CAS_ROOT_PROXIED_AS)
             else:
                 protocol = get_protocol(request)


### PR DESCRIPTION
If the proposed intended behaviour in #306 is considered correct, this change alters the url bluilding process accordingly