### PR TITLE
Improve redirect url when CAS_ROOT_PROXIED_AS is empty.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-cas-ng
 `django-cas-ng`_ is Django CAS (Central Authentication Service) 1.0/2.0/3.0 client
 library to support SSO (Single Sign On) and Single Logout (SLO).
 
-It supports Django 2.0, 2.1, 2.2, 3.0 and Python 3.5+!
+It supports Django 2.0, 2.1, 2.2, 3.0, 3.1, 3.2, 4.0 and Python 3.5+!
 
 **NOTE:**
 
@@ -38,7 +38,7 @@ Features
 - Support Single Logout (needs CAS server support)
 - Supports Token auth schemes
 - Can fetch Proxy Granting Ticket
-- Supports Django 2.0, 2.1, 2.2 and 3.0
+- Supports Django 2.0, 2.1, 2.2, 3.0, 3.1, 3.2 and 4.0
 - Supports using a `User custom model`_
 - Supports Python 3.5+
 - Supports typing hints in public API.

--- a/django_cas_ng/decorators.py
+++ b/django_cas_ng/decorators.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBase
-from django.utils.http import urlquote
+from urllib.parse import quote
 
 __all__ = ['login_required', 'permission_required', 'user_passes_test']
 # Retains the arguments and return type of original decorated function
@@ -40,7 +40,7 @@ def user_passes_test(test_func: Callable[[User], bool],
                 raise PermissionDenied
 
             path = '%s?%s=%s' % (login_url, redirect_field_name,
-                                 urlquote(request.get_full_path()))
+                                 quote(request.get_full_path()))
             return HttpResponseRedirect(path)
         return wrapper
     return decorator

--- a/django_cas_ng/utils.py
+++ b/django_cas_ng/utils.py
@@ -50,7 +50,7 @@ def get_redirect_url(request: HttpRequest) -> str:
 
 def get_service_url(request: HttpRequest, redirect_to: Optional[str] = None) -> str:
     """Generates application django service URL for CAS"""
-    if hasattr(django_settings, 'CAS_ROOT_PROXIED_AS'):
+    if hasattr(django_settings, 'CAS_ROOT_PROXIED_AS') and django_settings.CAS_ROOT_PROXIED_AS:
         service = urllib_parse.urljoin(django_settings.CAS_ROOT_PROXIED_AS, request.path)
     else:
         if django_settings.CAS_FORCE_SSL_SERVICE_URL:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Listed are the high-level, notable changes for each django-cas-ng release.
 Backwards incompatible changes or other upgrade issues are also described
 here. For additional detail, read the complete `commit history`_.
 
+**django-cas-ng x.y.z** ``[YYYY-MM-DD]``
+
+* PR #308: Improve redirect url when CAS_ROOT_PROXIED_AS is empty @mbaechtold
+
 **django-cas-ng 4.2.1** ``[2021-06-11]``
 
 * PR #290: Fix #289 Change in conditional in Middleware to avoid infinite redirects @elyak123

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,7 +6,7 @@ from django_cas_ng.middleware import CASMiddleware
 
 def _process_view_with_middleware(
         middleware_cls, url, view_func):
-    middleware = middleware_cls()
+    middleware = middleware_cls(view_func)
     request_factory = RequestFactory()
     request = request_factory.get(url)
     request.user = AnonymousUser()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,22 @@ def test_service_url_root_proxied_as(settings):
     assert actual == expected
 
 
+def test_service_url_root_proxied_as_empty_string(settings):
+    """
+    If the settings module has the attribute CAS_ROOT_PROXIED_AS but its value
+    is an empty string (or another falsy value), we must make sure the setting
+    is not considered while constructing the redirect url.
+    """
+    settings.CAS_ROOT_PROXIED_AS = ''
+
+    factory = RequestFactory()
+    request = factory.get('/login/')
+
+    actual = get_service_url(request)
+    expected = 'http://testserver/login/?next=%2F'
+    assert actual == expected
+
+
 def test_force_ssl_service_url(settings):
     settings.CAS_FORCE_SSL_SERVICE_URL = True
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,7 +15,7 @@ SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 # function takes a request and applies a middleware process
 def process_request_for_middleware(request, middleware):
-    middleware = middleware()
+    middleware = middleware("response")
     middleware.process_request(request)
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 
 def dummy_view():
@@ -6,5 +6,5 @@ def dummy_view():
 
 
 urlpatterns = [
-    url(r'^$', dummy_view, name="home"),
+    path('', dummy_view, name="home"),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomaster: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov
     pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist=
     py{36,37,38}-django30
     py{36,37,38}-django31
     py{36,37,38,39,310}-django32
+    py{38,39,310}-django40
     py{38,39,310}-djangomaster
     flake8
 
@@ -22,6 +23,7 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist=
     py{36,37,38}-django30
     py{36,37,38}-django31
     py{36,37,38,39,310}-django32
-    py{36,37,38}-djangomaster
+    py{38,39,310}-djangomaster
     flake8
 
 [flake8]


### PR DESCRIPTION
If the settings module has an attribute called `CAS_ROOT_PROXIED_AS` but its value is an empty string (or another falsy value), we must make sure the setting is not considered while constructing the redirect url.

This is the case if your Django application makes use of `django-configurations` which allows you to make some Django settings configurable by setting environment variables. So imagine the following settings module:

```
from configurations import Configuration
from configurations import values

class Settings(Configuration):
    CAS_ROOT_PROXIED_AS = values.Value("")
    ...
```

In this case, the `settings` module always has an attribute `CAS_ROOT_PROXIED_AS`. But it will only get a value if you configure an environment variable `DJANGO_ CAS_ROOT_PROXIED_AS`.