### PR TITLE
Add CAS affiliation support - closes #314

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -34,6 +34,7 @@ _DEFAULTS = {
     'CAS_FORCE_SSL_SERVICE_URL': False,
     'CAS_CHECK_NEXT': True,
     'CAS_SESSION_FACTORY': None,
+    'CAS_MAP_AFFILIATIONS': False,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -5,7 +5,7 @@ from typing import Mapping, Optional
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 
@@ -87,6 +87,14 @@ class CASBackend(ModelBackend):
 
         if pgtiou and settings.CAS_PROXY_CALLBACK and request:
             request.session['pgtiou'] = pgtiou
+
+        # Map CAS affiliations to Django groups
+        if settings.CAS_MAP_AFFILIATIONS and user and attributes:
+            affils = attributes.get('affiliation', [])
+            for affil in affils:
+                if affil:
+                    g = Group.objects.get_or_create(affil)
+                    user.groups.add(g)
 
         if settings.CAS_APPLY_ATTRIBUTES_TO_USER and attributes:
             # If we are receiving None for any values which cannot be NULL

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -343,6 +343,16 @@ Example usage:
     CAS_SESSION_FACTORY = cas_get_session
 
 
+``CAS_MAP_AFFILIATIONS`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If ``True``, django-cas-ng will create a Django group for each
+``affiliation`` that the CAS server associates with the user, during
+the authentication process.
+
+The default is ``False``.
+
+
 URL dispatcher
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
* Add new CAS_MAP_AFFILIATIONS config option

This option creates a django Group for each "affiliation" provided by
CAS. This allows us to use these groups to associate users with our own
custom Course model, either as students or faculty members.