### PR TITLE
Rename new setting to use AFFILIATIONS for consistency

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -28,7 +28,6 @@ _DEFAULTS = {
     'CAS_STORE_NEXT': False,
     'CAS_APPLY_ATTRIBUTES_TO_USER': False,
     'CAS_RENAME_ATTRIBUTES': {},
-    'CAS_AFFILIATION_HANDLERS': [],
     'CAS_CREATE_USER_WITH_ID': False,
     'CAS_VERIFY_SSL_CERTIFICATE': True,
     'CAS_LOCAL_NAME_FIELD': None,
@@ -36,6 +35,7 @@ _DEFAULTS = {
     'CAS_CHECK_NEXT': True,
     'CAS_SESSION_FACTORY': None,
     'CAS_MAP_AFFILIATIONS': False,
+    'CAS_AFFILIATIONS_HANDLERS': [],
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -96,9 +96,9 @@ class CASBackend(ModelBackend):
                     g, created = Group.objects.get_or_create(name=affil)
                     user.groups.add(g)
 
-        if settings.CAS_AFFILIATION_HANDLERS and user and attributes:
+        if settings.CAS_AFFILIATIONS_HANDLERS and user and attributes:
             affils = attributes.get('affiliation', [])
-            for handler in settings.CAS_AFFILIATION_HANDLERS:
+            for handler in settings.CAS_AFFILIATIONS_HANDLERS:
                 if (callable(handler)):
                     handler(user, affils)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -273,14 +273,6 @@ For example, if ``CAS_RENAME_ATTRIBUTES = {'ln':'last_name'}`` the ``ln`` attrib
 will be renamed as ``last_name``. Used with ``CAS_APPLY_ATTRIBUTES_TO_USER = True``, this provides an easy way
 to fill in Django Users' info independently from the attributes' keys returned by the CAS server.
 
-``CAS_AFFILIATION_HANDLERS`` [Optional]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is an optional list of functions to apply to the user's CAS
-affiliations. The callback is: ``handler(user, affils)``.
-
-The default is ``[]``.
-
 
 ``CAS_VERIFY_SSL_CERTIFICATE`` [Optional]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -359,6 +351,15 @@ If ``True``, django-cas-ng will create a Django group for each
 the authentication process.
 
 The default is ``False``.
+
+
+``CAS_AFFILIATIONS_HANDLERS`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is an optional list of functions to apply to the user's CAS
+affiliations. The callback is: ``handler(user, affils)``.
+
+The default is ``[]``.
 
 
 URL dispatcher


### PR DESCRIPTION
Alright, apologies for not having this right the first time. I just think this should actually be called AFILLIATIONS for consistency here, with the other affil config and the ATTRIBUTES settings.