### PR TITLE
perf: Change session_key max length to 768 for utf8mb4 index limit

### DIFF
--- a/django_cas_ng/migrations/0002_auto_20201023_1400.py
+++ b/django_cas_ng/migrations/0002_auto_20201023_1400.py
@@ -13,11 +13,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='proxygrantingticket',
             name='session_key',
-            field=models.CharField(blank=True, max_length=1024, null=True),
+            field=models.CharField(blank=True, max_length=768, null=True),
         ),
         migrations.AlterField(
             model_name='sessionticket',
             name='session_key',
-            field=models.CharField(max_length=1024),
+            field=models.CharField(max_length=768),
         ),
     ]

--- a/django_cas_ng/migrations/0002_auto_20201023_1400.py
+++ b/django_cas_ng/migrations/0002_auto_20201023_1400.py
@@ -13,11 +13,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='proxygrantingticket',
             name='session_key',
-            field=models.CharField(blank=True, max_length=768, null=True),
+            field=models.CharField(blank=True, max_length=736, null=True),
         ),
         migrations.AlterField(
             model_name='sessionticket',
             name='session_key',
-            field=models.CharField(max_length=768),
+            field=models.CharField(max_length=736),
         ),
     ]

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -10,7 +10,7 @@ from .utils import get_cas_client, get_user_from_session
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
-SESSION_KEY_MAXLENGTH = 1024
+SESSION_KEY_MAXLENGTH = 768
 
 
 class ProxyError(ValueError):

--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -10,7 +10,7 @@ from .utils import get_cas_client, get_user_from_session
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
-SESSION_KEY_MAXLENGTH = 768
+SESSION_KEY_MAXLENGTH = 736
 
 
 class ProxyError(ValueError):


### PR DESCRIPTION
Hi, 
We have has same issue with https://github.com/django-cas-ng/django-cas-ng/issues/317 ，
The maximum length of a MySQL or MariaDB index is 3072, so the maximum length of a utf8mb3 string is 1024, but the default character set of MySQL8, MariaDB 10 is now utf8mb4, so it is better to set to 768