### PR TITLE
Allow custom "next_page" in LoginView and LogoutView get method

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -36,6 +36,8 @@ _DEFAULTS = {
     'CAS_SESSION_FACTORY': None,
     'CAS_MAP_AFFILIATIONS': False,
     'CAS_AFFILIATIONS_HANDLERS': [],
+    'CAS_LOGIN_NEXT_PAGE': None,
+    'CAS_LOGOUT_NEXT_PAGE': None,
 }
 
 for key, value in list(_DEFAULTS.items()):

--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -100,7 +100,13 @@ class LoginView(View):
         :param request:
         :return:
         """
-        next_page = clean_next_page(request, request.GET.get('next'))
+        next_url = getattr(
+            settings,
+            "CAS_LOGIN_NEXT_PAGE",
+            request.GET.get("next"),
+        )
+        next_page = clean_next_page(request, next_url)
+
         required = request.GET.get('required', False)
 
         service_url = get_service_url(request, next_page)
@@ -190,7 +196,12 @@ class LogoutView(View):
         :param request:
         :return:
         """
-        next_page = clean_next_page(request, request.GET.get('next'))
+        next_url = getattr(
+            settings,
+            "CAS_LOGOUT_NEXT_PAGE",
+            request.GET.get("next"),
+        )
+        next_page = clean_next_page(request, next_url)
 
         # try to find the ticket matching current session for logout signal
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -361,6 +361,24 @@ affiliations. The callback is: ``handler(user, affils)``.
 
 The default is ``[]``.
 
+``CAS_LOGIN_NEXT_PAGE`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The relative path where to send a user after logging in.
+It may be different than CAS_REDIRECT_URL, for example if you want to use a
+specific callback function.
+
+The default is ``None``.
+
+``CAS_LOGOUT_NEXT_PAGE`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The relative path where to send a user after logging out.
+It may be different than CAS_REDIRECT_URL, for example if you want to use a
+specific callback function.
+
+The default is ``None``.
+
 
 URL dispatcher
 ^^^^^^^^^^^^^^

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -22,6 +22,7 @@ Credits
 * `Peter Baehr`_
 * `laymonage`_
 * `Michael Phelps`_
+* `Alica Burlot`_
 
 .. _django-cas: https://bitbucket.org/cpcc/django-cas
 .. _Jasig CAS server: http://jasig.github.io/cas
@@ -44,3 +45,4 @@ Credits
 .. _Peter Baehr: https://github.com/pbaehr
 .. _laymonage: https://github.com/laymonage
 .. _Michael Phelps: https://github.com/nottheswimmer
+.. _Alica Burlot: https://github.com/B-Alica


### PR DESCRIPTION
Hello,

In the get method of LoginView and LogoutView, there is a "next_page" which is next_page = clean_next_page(request, request.GET.get('next')).
But I needed to override this and provide my own path for next_page. I figured it might be useful for other users as well.

I added two variables to settings: CAS_LOGIN_NEXT_PAGE and CAS_LOGOUT_NEXT_PAGE, to be able to provide a custom path.

I hope everything works well.