### PR TITLE
setup.cfg: don't build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.txt
 


### PR DESCRIPTION
We don't need a universal wheel on this package because it doesn't support python 2.