### PR TITLE
Refactor CAS affiliation retrieval to use configurable key

### DIFF
--- a/django_cas_ng/__init__.py
+++ b/django_cas_ng/__init__.py
@@ -36,6 +36,7 @@ _DEFAULTS = {
     'CAS_SESSION_FACTORY': None,
     'CAS_MAP_AFFILIATIONS': False,
     'CAS_AFFILIATIONS_HANDLERS': [],
+    'CAS_AFFILIATIONS_KEY': 'affiliation',
     'CAS_LOGIN_NEXT_PAGE': None,
     'CAS_LOGOUT_NEXT_PAGE': None,
 }

--- a/django_cas_ng/backends.py
+++ b/django_cas_ng/backends.py
@@ -90,14 +90,14 @@ class CASBackend(ModelBackend):
 
         # Map CAS affiliations to Django groups
         if settings.CAS_MAP_AFFILIATIONS and user and attributes:
-            affils = attributes.get('affiliation', [])
+            affils = attributes.get(settings.CAS_AFFILIATIONS_KEY, [])
             for affil in affils:
                 if affil:
                     g, created = Group.objects.get_or_create(name=affil)
                     user.groups.add(g)
 
         if settings.CAS_AFFILIATIONS_HANDLERS and user and attributes:
-            affils = attributes.get('affiliation', [])
+            affils = attributes.get(settings.CAS_AFFILIATIONS_KEY, [])
             for handler in settings.CAS_AFFILIATIONS_HANDLERS:
                 if (callable(handler)):
                     handler(user, affils)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -373,6 +373,17 @@ affiliations. The callback is: ``handler(user, affils)``.
 
 The default is ``[]``.
 
+
+``CAS_AFFILIATIONS_KEY`` [Optional]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This variable defines the key used to retrieve the CAS affiliations
+from the authentication attributes. If your CAS server returns the
+affiliations under a different key, you can change this value accordingly.
+
+The default is ``affiliation``.
+
+
 ``CAS_LOGIN_NEXT_PAGE`` [Optional]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -23,6 +23,7 @@ Credits
 * `laymonage`_
 * `Michael Phelps`_
 * `Alica Burlot`_
+* `Rodrigo Fernandez`_
 
 .. _django-cas: https://bitbucket.org/cpcc/django-cas
 .. _Jasig CAS server: http://jasig.github.io/cas
@@ -46,3 +47,4 @@ Credits
 .. _laymonage: https://github.com/laymonage
 .. _Michael Phelps: https://github.com/nottheswimmer
 .. _Alica Burlot: https://github.com/B-Alica
+.. _Rodrigo Fernandez: https://github.com/rfernandezfranco


### PR DESCRIPTION
Replace the hardcoded 'affiliation' key with settings.CAS_AFFILIATIONS_KEY (defaulting to 'affiliation') in the authenticate function to obtain CAS group memberships. This change improves flexibility by allowing the key to be easily customized for different CAS attribute structures.