### PR TITLE
Remove transitive dependency lxml from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==4.2.22
-lxml>=3.4
 
 # If you want the latest python-cas, uncomment following line.
 #-e git+https://github.com/python-cas/python-cas.git#egg=python_cas


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `lxml` is specified as a requirement in the `requirements.txt` file, when in reality it is not needed.

This PR removes it from `requirements.txt` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards