### PR TITLE
refactor: use tuple in startswith to avoid redundant lower() call

### DIFF
--- a/django_cas_ng/views.py
+++ b/django_cas_ng/views.py
@@ -232,7 +232,7 @@ class LogoutView(View):
 
         next_page = next_page or get_redirect_url(request)
         if settings.CAS_LOGOUT_COMPLETELY:
-            if next_page.lower().startswith("https://") or next_page.lower().startswith("http://"):
+            if next_page.lower().startswith(("https://", "http://")):
                 redirect_url = next_page
             else:
                 if hasattr(settings, 'CAS_ROOT_PROXIED_AS') and settings.CAS_ROOT_PROXIED_AS:


### PR DESCRIPTION
Wow, cool repo! 
I noticed that in the 'LogoutView.get' method in 'views.py',  'next_page.lower()' was called twice in the same condition. I replaced it with a single 'startswith' call using a tuple, which checks both prefixes in one call and only computes `.lower()` once. 
I'm happy to make any changes if necessary. Hope this helps! 